### PR TITLE
Rename project to HiveMQ APN Bridge Extension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 Welcome to the HiveMQ Community!
-Glad to see your interest in contributing to HiveMQ Hello World Extension.
+Glad to see your interest in contributing to HiveMQ APN Bridge Extension.
 Please checkout our [Contribution Guide](https://github.com/hivemq/hivemq-community/blob/master/CONTRIBUTING.adoc) to make sure your contribution will be accepted by the HiveMQ team.
 
 For information on how the HiveMQ Community is organized and how contributions will be accepted please have a look at our [HiveMQ Community Repo](https://github.com/hivemq/hivemq-community).

--- a/README.adoc
+++ b/README.adoc
@@ -5,16 +5,16 @@
 :hivemq-testcontainer: https://github.com/hivemq/hivemq-testcontainer
 :hivemq-mqtt-client: https://github.com/hivemq/hivemq-mqtt-client
 
-= HiveMQ 4 Hello World Extension
+= HiveMQ APN Bridge Extension
 
 image:https://img.shields.io/badge/Extension_Type-Demonstration-orange?style=for-the-badge[Extension Type]
-image:https://img.shields.io/github/v/release/hivemq/hivemq-hello-world-extension?style=for-the-badge[GitHub release (latest by date),link=https://github.com/hivemq/hivemq-hello-world-extension/releases/latest]
-image:https://img.shields.io/github/license/hivemq/hivemq-hello-world-extension?style=for-the-badge&color=brightgreen[GitHub,link=LICENSE]
-image:https://img.shields.io/github/actions/workflow/status/hivemq/hivemq-hello-world-extension/check.yml?branch=master&style=for-the-badge[GitHub Workflow Status,link=https://github.com/hivemq/hivemq-hello-world-extension/actions/workflows/check.yml?query=branch%3Amaster]
+image:https://img.shields.io/github/v/release/hivemq/hivemq-apn-bridge-extension?style=for-the-badge[GitHub release (latest by date),link=https://github.com/hivemq/hivemq-apn-bridge-extension/releases/latest]
+image:https://img.shields.io/github/license/hivemq/hivemq-apn-bridge-extension?style=for-the-badge&color=brightgreen[GitHub,link=LICENSE]
+image:https://img.shields.io/github/actions/workflow/status/hivemq/hivemq-apn-bridge-extension/check.yml?branch=master&style=for-the-badge[GitHub Workflow Status,link=https://github.com/hivemq/hivemq-apn-bridge-extension/actions/workflows/check.yml?query=branch%3Amaster]
 
 == Purpose
 
-This Hello World extension sets a ClientLifecycleEventListener which logs the MQTT Version and identifier of every connecting and disconnecting client and registers a PublishInboundInterceptor to modify the payload of every Publish with the topic 'hello/world' to 'Hello World!'.
+This HiveMQ APN Bridge Extension sets a ClientLifecycleEventListener which logs the MQTT Version and identifier of every connecting and disconnecting client and registers a PublishInboundInterceptor to modify the payload of every Publish with the topic 'hello/world' to 'Hello World!'.
 
 We strongly recommend to read the {hivemq-extension-docs}[HiveMQ Extension Documentation] to grasp the core concepts of HiveMQ extension development.
 
@@ -22,7 +22,7 @@ We strongly recommend to read the {hivemq-extension-docs}[HiveMQ Extension Docum
 
 . Clone this repository into a Java 11 Gradle project.
 . Execute the Gradle task `hivemqExtensionZip` to build the extension.
-. Move the file: `build/hivemq-extension/hivemq-hello-world-extension-4.43.0.zip` to the directory: `HIVEMQ_HOME/extensions`
+. Move the file: `build/hivemq-extension/hivemq-apn-bridge-extension-4.43.0.zip` to the directory: `HIVEMQ_HOME/extensions`
 . Unzip the file.
 . Start HiveMQ.
 
@@ -53,9 +53,9 @@ The best place to get in contact is our {hivemq-support}[support^].
 
 == Contributing
 
-If you want to contribute to HiveMQ Hello World Extension, see the link:CONTRIBUTING.md[contribution guidelines].
+If you want to contribute to HiveMQ APN Bridge Extension, see the link:CONTRIBUTING.md[contribution guidelines].
 
 == License
 
-HiveMQ Hello World Extension is licensed under the `APACHE LICENSE, VERSION 2.0`.
+HiveMQ APN Bridge Extension is licensed under the `APACHE LICENSE, VERSION 2.0`.
 A copy of the license can be found link:LICENSE[here].

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
 }
 
 group = "com.hivemq.extensions"
-description = "HiveMQ 4 Hello World Extension - a simple reference for all extension developers"
+description = "HiveMQ APN Bridge Extension - a simple reference for all extension developers"
 
 hivemqExtension {
-    name = "Hello World Extension"
+    name = "HiveMQ APN Bridge Extension"
     author = "HiveMQ"
     priority = 1000
     startPriority = 1000

--- a/renovate.json5
+++ b/renovate.json5
@@ -8,7 +8,7 @@
         'renovate-playground',
     ],
     useBaseBranchConfig: 'merge',
-    branchPrefix: 'renovate/hivemq-hello-world-extension/',
+    branchPrefix: 'renovate/hivemq-apn-bridge-extension/',
     addLabels: [
         'integrations-team-coordination',
     ],

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "hivemq-hello-world-extension"
+rootProject.name = "hivemq-apn-bridge-extension"

--- a/src/integrationTest/java/com/hivemq/extensions/helloworld/HelloWorldInterceptorIT.java
+++ b/src/integrationTest/java/com/hivemq/extensions/helloworld/HelloWorldInterceptorIT.java
@@ -47,7 +47,7 @@ class HelloWorldInterceptorIT {
 
     @Container
     final @NotNull HiveMQContainer extension = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq-ce").withTag("latest"))
-            .withExtension(MountableFile.forClasspathResource("hivemq-hello-world-extension"));
+            .withExtension(MountableFile.forClasspathResource("hivemq-apn-bridge-extension"));
 
     @Test
     @Timeout(value = 5, unit = TimeUnit.MINUTES)


### PR DESCRIPTION
## Summary
- rename the Gradle project and extension metadata to HiveMQ APN Bridge Extension
- update documentation, badges, and tooling references to the new project name
- adjust integration test resources to point to the renamed extension artifact

## Testing
- `./gradlew check` *(fails: repository returned HTTP 403 for org.mockito:mockito-core:5.19.0)*

------
https://chatgpt.com/codex/tasks/task_e_68cff3c9a5c88329aac3c355ea8fefa7